### PR TITLE
Issue 16 add command line interface

### DIFF
--- a/Evolve.sln
+++ b/Evolve.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2026
@@ -50,6 +49,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcore2", "netcore2", "{CD98E896-B15B-433A-ABA6-B1EDC4594C92}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Evolve.IntegrationTest.Cassandra", "test\Evolve.IntegrationTest.Cassandra\Evolve.IntegrationTest.Cassandra.csproj", "{8D46203E-CB14-483B-AF9F-2BEB57734EE7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Evolve.Cli", "src\Evolve.Cli\Evolve.Cli.csproj", "{1F0F6545-9F3C-4D48-9A37-02BF590D1825}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -227,6 +228,18 @@ Global
 		{8D46203E-CB14-483B-AF9F-2BEB57734EE7}.Release|x64.Build.0 = Release|Any CPU
 		{8D46203E-CB14-483B-AF9F-2BEB57734EE7}.Release|x86.ActiveCfg = Release|Any CPU
 		{8D46203E-CB14-483B-AF9F-2BEB57734EE7}.Release|x86.Build.0 = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Debug|x86.Build.0 = Debug|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|x64.Build.0 = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,6 +262,7 @@ Global
 		{FFD85E72-3130-47CA-9FE0-D65546721DD1} = {CD98E896-B15B-433A-ABA6-B1EDC4594C92}
 		{CD98E896-B15B-433A-ABA6-B1EDC4594C92} = {7FA35BAF-800D-4435-9E01-58CBBDDF9C69}
 		{8D46203E-CB14-483B-AF9F-2BEB57734EE7} = {DA652844-26F0-4FFF-95E4-5882CEAA6B12}
+		{1F0F6545-9F3C-4D48-9A37-02BF590D1825} = {2A25B1AD-2629-4D99-BAB5-172EED85FFE8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {220554C7-B098-4FF6-8B7A-96E72B90D7B4}

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#tool "nuget:?package=ILRepack"
+
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 ///////////////////////////////////////////////////////////////////////////////
@@ -75,7 +77,6 @@ Task("Test").WithCriteria(() => IsRunningOnWindows()).Does(() =>
 
 Task("Test Core").Does(() =>
 {
-
     foreach(var project in GetFiles("./test/**/Evolve.Core*.Test.Resources.SupportedDrivers.csproj"))
     {
         DotNetCoreBuild(project.FullPath, new DotNetCoreBuildSettings 
@@ -116,6 +117,12 @@ Task("Pack").Does(() =>
     {
         NuGetPack("./src/Evolve/Evolve-Core.nuspec", settings);
     }
+});
+
+Task("PackCli").WithCriteria(() => IsRunningOnWindows()).Does(() =>
+{
+    var assemblies = GetFiles("./src/Evolve.Cli/bin/Release/net452/*.dll");
+    ILRepack("./dist/Evolve.exe", "./src/Evolve.Cli/bin/Release/net452/Evolve.Cli.exe", assemblies);
 });
 
 Task("Restore Test-Package").Does(() =>
@@ -173,6 +180,7 @@ Task("Default")
     .IsDependentOn("Test")
     .IsDependentOn("Test Core")
     .IsDependentOn("Pack")
+    .IsDependentOn("PackCli")
     .IsDependentOn("Restore Test-Package")
     .IsDependentOn("Build Test-Package")
     .IsDependentOn("Build Test-Package Core");

--- a/src/Evolve.Cli/CassandraOptions.cs
+++ b/src/Evolve.Cli/CassandraOptions.cs
@@ -6,6 +6,8 @@ namespace Evolve.Cli
     [Verb("cassandra", HelpText = "Evolve with Cassandra")]
     internal class CassandraOptions : Options
     {
+        public override string Driver => "cassandra";
+
         [Option('k', "metadata-table-keyspace", HelpText = "The keyspace in which the metadata table is/should be", Required = true)]
         public string MetadataTableKeyspace { get; set; }
 

--- a/src/Evolve.Cli/CassandraOptions.cs
+++ b/src/Evolve.Cli/CassandraOptions.cs
@@ -6,19 +6,19 @@ namespace Evolve.Cli
     [Verb("cassandra", HelpText = "Evolve with Cassandra")]
     internal class CassandraOptions : Options
     {
-        [Option('k', "metadata-table-keyspace", HelpText = "The keyspace in which the metadata table is/should be")]
+        [Option('k', "metadata-table-keyspace", HelpText = "The keyspace in which the metadata table is/should be", Required = true)]
         public string MetadataTableKeyspace { get; set; }
 
-        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = "Cql_Scripts")]
+        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = new[] { "Cql_Scripts" })]
         public new IEnumerable<string> Locations { get; set; }
 
         [Option("keyspaces", HelpText = "A list of keyspaces managed by Evolve. If empty, the default schema for the datasource connection is used.")]
         public IEnumerable<string> Keyspaces { get; set; }
 
-        [Option("erase-enabled", HelpText = "Allows Evolve to erase keyspaces and tables. Intended to be used in development only.", Default = false)]
-        public new bool EraseEnabled { get; set; }
+        [Option("enable-erase", HelpText = "Allows Evolve to erase keyspaces and tables. Intended to be used in development only.", Default = false)]
+        public new bool EnableErase { get; set; }
 
-        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the keyspaces and will re-execute migration scripts from scratch. Intended to be used in development only.")]
+        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the keyspaces and will re-execute migration scripts from scratch. Intended to be used in development only.", Default = false)]
         public new bool EraseOnValidationError { get; set; }
 
         [Option("scripts-suffix", HelpText = "Migration scripts files extension.", Default = ".cql")]

--- a/src/Evolve.Cli/CassandraOptions.cs
+++ b/src/Evolve.Cli/CassandraOptions.cs
@@ -1,0 +1,27 @@
+﻿using CommandLine;
+using System.Collections.Generic;
+
+namespace Evolve.Cli
+{
+    [Verb("cassandra", HelpText = "Evolve with Cassandra")]
+    internal class CassandraOptions : Options
+    {
+        [Option('k', "metadata-table-keyspace", HelpText = "The keyspace in which the metadata table is/should be")]
+        public string MetadataTableKeyspace { get; set; }
+
+        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = "Cql_Scripts")]
+        public new IEnumerable<string> Locations { get; set; }
+
+        [Option("keyspaces", HelpText = "A list of keyspaces managed by Evolve. If empty, the default schema for the datasource connection is used.")]
+        public IEnumerable<string> Keyspaces { get; set; }
+
+        [Option("erase-enabled", HelpText = "Allows Evolve to erase keyspaces and tables. Intended to be used in development only.", Default = false)]
+        public new bool EraseEnabled { get; set; }
+
+        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the keyspaces and will re-execute migration scripts from scratch. Intended to be used in development only.")]
+        public new bool EraseOnValidationError { get; set; }
+
+        [Option("scripts-suffix", HelpText = "Migration scripts files extension.", Default = ".cql")]
+        public new string ScriptsSuffix { get; set; }
+    }
+}

--- a/src/Evolve.Cli/Command.cs
+++ b/src/Evolve.Cli/Command.cs
@@ -1,6 +1,6 @@
 ﻿namespace Evolve.Cli
 {
-    internal enum Commands
+    internal enum Command
     {
         //Lowercase because of some parsing issue with CommandLineParser library
         //https://github.com/commandlineparser/commandline/issues/198

--- a/src/Evolve.Cli/Commands.cs
+++ b/src/Evolve.Cli/Commands.cs
@@ -1,0 +1,11 @@
+﻿namespace Evolve.Cli
+{
+    internal enum Commands
+    {
+        //Lowercase because of some parsing issue with CommandLineParser library
+        //https://github.com/commandlineparser/commandline/issues/198
+        migrate,
+        erase,
+        repair
+    }
+}

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net452;</TargetFrameworks>
+    <Version>$(PackageVersion)</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
@@ -22,14 +24,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
     <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="1.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="MySql.Data" Version="8.0.9-dmr" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="2.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,40 +6,11 @@
     <Version>$(PackageVersion)</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
-    <DefineConstants>NET;NET45</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
-    <DefineConstants>NETCORE;NETCORE1</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0' ">
-    <DefineConstants>NETCORE;NETCORE2</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="CassandraCSharpDriver" Version="3.4.1" />
-    <PackageReference Include="Npgsql" Version="3.2.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
-    <PackageReference Include="Microsoft.Data.SQLite" Version="1.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="MySql.Data" Version="8.0.9-dmr" />
-    <PackageReference Include="Microsoft.Data.SQLite" Version="2.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.107.0" />
-  </ItemGroup>
-
-    <ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Evolve\Evolve.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -7,6 +7,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="CassandraCSharpDriver" Version="3.4.1" />
+    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="Npgsql" Version="3.2.6" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="2.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Evolve\Evolve.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -1,19 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net452;</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
+    <DefineConstants>NET;NET45</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <DefineConstants>NETCORE;NETCORE1</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0' ">
+    <DefineConstants>NETCORE;NETCORE2</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="CassandraCSharpDriver" Version="3.4.1" />
-    <PackageReference Include="MySql.Data" Version="6.10.6" />
     <PackageReference Include="Npgsql" Version="3.2.6" />
-    <PackageReference Include="Microsoft.Data.SQLite" Version="2.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="MySql.Data" Version="8.0.9-dmr" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="MySql.Data" Version="6.10.6" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.107.0" />
+  </ItemGroup>
+
+    <ItemGroup>
     <ProjectReference Include="..\Evolve\Evolve.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -1,0 +1,90 @@
+﻿using Evolve.Configuration;
+using Evolve.Migration;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace Evolve.Cli
+{
+    internal static class EvolveFactory
+    {
+        public static Evolve Build(IDbConnection connection, Options options)
+        {
+            var evolve = new Evolve(connection)
+            {
+                Command = MapToCommandOptions(options.Command),
+                CommandTimeout = options.Timeout,
+                EnableClusterMode = !options.DisableClusterMode,
+                Encoding = ParseEncoding(options.Encoding),
+                IsEraseDisabled = !options.EraseEnabled,
+                Locations = options.Locations,
+                MetadataTableName = options.MetadataTableName,
+                OutOfOrder = options.OutOfOrder,
+                SqlMigrationSuffix = options.ScriptsSuffix,
+                PlaceholderPrefix = options.PlaceholderPrefix,
+                PlaceholderSuffix = options.PlaceholderSuffix,
+                Placeholders = MapPlaceholders(options.Placeholders),
+                SqlMigrationPrefix = options.MigrationScriptsPrefix,
+                SqlMigrationSeparator = options.MigrationScriptsSeparator,
+                StartVersion = ParseVersion(options.StartVersion),
+                TargetVersion = ParseVersion(options.TargetVersion)
+            };
+
+            switch (options)
+            {
+                case SqlOptions sqlOptions:
+                    evolve.MetadataTableSchema = sqlOptions.MetadataTableSchema;
+                    evolve.Schemas = sqlOptions.Schemas;
+                    break;
+                case CassandraOptions cassandraOptions:
+                    evolve.MetadataTableSchema = cassandraOptions.MetadataTableKeyspace;
+                    evolve.Locations = cassandraOptions.Locations;
+                    evolve.Schemas = cassandraOptions.Keyspaces;
+                    evolve.IsEraseDisabled = !cassandraOptions.EraseEnabled;
+                    evolve.MustEraseOnValidationError = cassandraOptions.EraseOnValidationError;
+                    evolve.SqlMigrationSuffix = cassandraOptions.ScriptsSuffix;
+                    break;
+
+            }
+
+            return evolve;
+        }
+
+        private static MigrationVersion ParseVersion(string version)
+        {
+            return new MigrationVersion(version);
+        }
+
+        private static Dictionary<string, string> MapPlaceholders(IEnumerable<string> placeholders) =>
+            placeholders.Select(i => i.Split(':')).ToDictionary(i => i[0], i => i[1]);
+
+        private static Encoding ParseEncoding(string encoding)
+        {
+            try
+            {
+                return Encoding.GetEncoding(encoding);
+            }
+            catch
+            {
+                return Encoding.UTF8;
+            }
+        }
+
+        private static CommandOptions MapToCommandOptions(Commands command)
+        {
+            switch (command)
+            {
+                case Commands.migrate:
+                    return CommandOptions.Migrate;
+                case Commands.erase:
+                    return CommandOptions.Erase;
+                case Commands.repair:
+                    return CommandOptions.Repair;
+                default:
+                    return CommandOptions.DoNothing;
+            }
+        }
+    }
+}

--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -10,12 +10,14 @@ namespace Evolve.Cli
 {
     internal static class EvolveFactory
     {
-        public static Evolve Build(IDbConnection connection, Options options)
+        public static Evolve Build(Options options)
         {
-            var evolve = new Evolve(connection, Console.WriteLine)
+            var evolve = new Evolve(logInfoDelegate: Console.WriteLine)
             {
                 Command = MapToCommandOptions(options.Command),
                 CommandTimeout = options.Timeout,
+                ConnectionString = options.ConnectionString,
+                Driver = options.Driver,
                 EnableClusterMode = !options.DisableClusterMode,
                 Encoding = ParseEncoding(options.Encoding),
                 IsEraseDisabled = !options.EnableErase,
@@ -70,15 +72,15 @@ namespace Evolve.Cli
             }
         }
 
-        private static CommandOptions MapToCommandOptions(Commands command)
+        private static CommandOptions MapToCommandOptions(Command command)
         {
             switch (command)
             {
-                case Commands.migrate:
+                case Command.migrate:
                     return CommandOptions.Migrate;
-                case Commands.erase:
+                case Command.erase:
                     return CommandOptions.Erase;
-                case Commands.repair:
+                case Command.repair:
                     return CommandOptions.Repair;
                 default:
                     return CommandOptions.DoNothing;

--- a/src/Evolve.Cli/MySqlOptions.cs
+++ b/src/Evolve.Cli/MySqlOptions.cs
@@ -3,5 +3,8 @@
 namespace Evolve.Cli
 {
     [Verb("mysql", HelpText = "Evolve with MySQL")]
-    internal class MySqlOptions : SqlOptions { }
+    internal class MySqlOptions : SqlOptions
+    {
+        public override string Driver => "mysql";
+    }
 }

--- a/src/Evolve.Cli/MySqlOptions.cs
+++ b/src/Evolve.Cli/MySqlOptions.cs
@@ -1,0 +1,7 @@
+﻿using CommandLine;
+
+namespace Evolve.Cli
+{
+    [Verb("mysql", HelpText = "Evolve with MySQL")]
+    internal class MySqlOptions : SqlOptions { }
+}

--- a/src/Evolve.Cli/Options.cs
+++ b/src/Evolve.Cli/Options.cs
@@ -1,0 +1,62 @@
+﻿using CommandLine;
+using System.Collections.Generic;
+
+namespace Evolve.Cli
+{
+    internal abstract class Options
+    {
+        [Value(0, MetaName = "command", HelpText = "migrate | erase | repair", Required = true)]
+        public Commands Command { get; set; }
+
+        [Value(1, MetaName = "connection-string", HelpText = "The connection string to the target engine.", Required = true)]
+        public string ConnectionString { get; set; }
+
+        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = "Sql_Scripts")]
+        public IEnumerable<string> Locations { get; set; }
+
+        [Option("timeout", HelpText = "The timetout in seconds for Evolve execution.", Default = 30)]
+        public int Timeout { get; set; }
+
+        [Option('t', "metadata-table", HelpText = "The name of the metadata table.", Default = "evolve_change_log")]
+        public string MetadataTableName { get; set; }
+
+        [Option("erase-enabled", HelpText = "Allows Evolve to erase schema and tables. Intended to be used in development only.", Default = false)]
+        public bool EraseEnabled { get; set; }
+
+        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the database schemas and will re-execute migration scripts from scratch. Intended to be used in development only.")]
+        public bool EraseOnValidationError { get; set; }
+
+        [Option('v', "target-version", HelpText = "Target version to reach. If empty it evolves all the way up.")]
+        public string TargetVersion { get; set; }
+
+        [Option("start-version", HelpText = "Version used as starting point for already existing databases.", Default = "0")]
+        public string StartVersion { get; set; }
+
+        [Option("out-of-order", HelpText = "Allows migration scripts to be run “out of order”. If you already have versions 1 and 3 applied, and now a version 2 is found, it will be applied too instead of being ignored.", Default = false)]
+        public bool OutOfOrder { get; set; }
+
+        [Option("encoding", HelpText = "The encoding of migration scripts.", Default = "UTF-8")]
+        public string Encoding { get; set; }
+
+        [Option("scripts-prefix", HelpText = "Migration scripts file names prefix", Default = "V")]
+        public string MigrationScriptsPrefix { get; set; }
+
+        [Option("scripts-separator", HelpText = "Migration scripts file names separator", Default = "__")]
+        public string MigrationScriptsSeparator { get; set; }
+
+        [Option("scripts-suffix", HelpText = "Migration scripts files extension.", Default = ".sql")]
+        public string ScriptsSuffix { get; set; }
+
+        [Option("placeholder-prefix", HelpText = "The prefix of the placeholders.", Default = "${")]
+        public string PlaceholderPrefix { get; set; }
+
+        [Option("placeholder-suffix", HelpText = "The suffix of the placeholders.", Default = "}")]
+        public string PlaceholderSuffix { get; set; }
+
+        [Option("placeholders", HelpText = "Placeholders are strings prefixed by: “Evolve.Placeholder.” to replace in migration scripts. Format for commandline is \"key:value\".")]
+        public IEnumerable<string> Placeholders { get; set; }
+
+        [Option("disable-cluster-mode", HelpText = "By default, Evolve will use a session level lock to coordinate the migration on multiple nodes. This prevents two distinct Evolve executions from executing an Evolve command on the same database at the same time. If this flag is set, it will not be the case.", Default = false)]
+        public bool DisableClusterMode { get; set; }
+    }
+}

--- a/src/Evolve.Cli/Options.cs
+++ b/src/Evolve.Cli/Options.cs
@@ -5,8 +5,10 @@ namespace Evolve.Cli
 {
     internal abstract class Options
     {
+        public abstract string Driver { get; }
+
         [Value(0, MetaName = "command", HelpText = "migrate | erase | repair", Required = true)]
-        public Commands Command { get; set; }
+        public Command Command { get; set; }
 
         [Value(1, MetaName = "connection-string", HelpText = "The connection string to the target engine.", Required = true)]
         public string ConnectionString { get; set; }

--- a/src/Evolve.Cli/Options.cs
+++ b/src/Evolve.Cli/Options.cs
@@ -11,7 +11,7 @@ namespace Evolve.Cli
         [Value(1, MetaName = "connection-string", HelpText = "The connection string to the target engine.", Required = true)]
         public string ConnectionString { get; set; }
 
-        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = "Sql_Scripts")]
+        [Option('l', "scripts-locations", HelpText = "Paths to scan recursively for migration scripts.", Default = new[] { "Sql_Scripts" })]
         public IEnumerable<string> Locations { get; set; }
 
         [Option("timeout", HelpText = "The timetout in seconds for Evolve execution.", Default = 30)]
@@ -20,13 +20,13 @@ namespace Evolve.Cli
         [Option('t', "metadata-table", HelpText = "The name of the metadata table.", Default = "evolve_change_log")]
         public string MetadataTableName { get; set; }
 
-        [Option("erase-enabled", HelpText = "Allows Evolve to erase schema and tables. Intended to be used in development only.", Default = false)]
-        public bool EraseEnabled { get; set; }
+        [Option("enable-erase", HelpText = "Allows Evolve to erase schema and tables. Intended to be used in development only.", Default = false)]
+        public bool EnableErase { get; set; }
 
-        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the database schemas and will re-execute migration scripts from scratch. Intended to be used in development only.")]
+        [Option("erase-on-validation-error", HelpText = "When set, if validation phase fails, Evolve will erase the database schemas and will re-execute migration scripts from scratch. Intended to be used in development only.", Default = false)]
         public bool EraseOnValidationError { get; set; }
 
-        [Option('v', "target-version", HelpText = "Target version to reach. If empty it evolves all the way up.")]
+        [Option('v', "target-version", HelpText = "Target version to reach. If empty it evolves all the way up.", Required = false)]
         public string TargetVersion { get; set; }
 
         [Option("start-version", HelpText = "Version used as starting point for already existing databases.", Default = "0")]
@@ -53,7 +53,7 @@ namespace Evolve.Cli
         [Option("placeholder-suffix", HelpText = "The suffix of the placeholders.", Default = "}")]
         public string PlaceholderSuffix { get; set; }
 
-        [Option("placeholders", HelpText = "Placeholders are strings prefixed by: “Evolve.Placeholder.” to replace in migration scripts. Format for commandline is \"key:value\".")]
+        [Option("placeholders", HelpText = "Placeholders are strings prefixed by: “Evolve.Placeholder.” to replace in migration scripts. Format for commandline is \"key:value\".", Required = false)]
         public IEnumerable<string> Placeholders { get; set; }
 
         [Option("disable-cluster-mode", HelpText = "By default, Evolve will use a session level lock to coordinate the migration on multiple nodes. This prevents two distinct Evolve executions from executing an Evolve command on the same database at the same time. If this flag is set, it will not be the case.", Default = false)]

--- a/src/Evolve.Cli/PostgreSqlOptions.cs
+++ b/src/Evolve.Cli/PostgreSqlOptions.cs
@@ -1,0 +1,7 @@
+﻿using CommandLine;
+
+namespace Evolve.Cli
+{
+    [Verb("postgresql", HelpText = "Evolve with PostgreSQL")]
+    internal class PostgreSqlOptions : SqlOptions { }
+}

--- a/src/Evolve.Cli/PostgreSqlOptions.cs
+++ b/src/Evolve.Cli/PostgreSqlOptions.cs
@@ -3,5 +3,8 @@
 namespace Evolve.Cli
 {
     [Verb("postgresql", HelpText = "Evolve with PostgreSQL")]
-    internal class PostgreSqlOptions : SqlOptions { }
+    internal class PostgreSqlOptions : SqlOptions
+    {
+        public override string Driver => "npgsql";
+    }
 }

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -1,15 +1,4 @@
-﻿using Cassandra.Data;
-using CommandLine;
-using MySql.Data.MySqlClient;
-using Npgsql;
-using System.Data;
-using System.Data.SqlClient;
-
-#if NETCORE
-using Microsoft.Data.Sqlite;
-#elif NET
-using System.Data.SQLite;
-#endif
+﻿using CommandLine;
 
 namespace Evolve.Cli
 {
@@ -20,38 +9,19 @@ namespace Evolve.Cli
             Parser.Default
                 .ParseArguments<CassandraOptions, MySqlOptions, PostgreSqlOptions, SQLiteOptions, SqlServerOptions>(args)
                 .MapResult(
-                    (CassandraOptions o) => EvolveWithCassandra(o),
-                    (MySqlOptions o) => EvolveWithMySql(o),
-                    (PostgreSqlOptions o) => EvolveWithPostgreSql(o),
-                    (SqlServerOptions o) => EvolveWithSqlServer(o),
-                    (SQLiteOptions o) => EvolveWithSQLite(o),
+                    (CassandraOptions o) => Evolve(o),
+                    (MySqlOptions o) => Evolve(o),
+                    (PostgreSqlOptions o) => Evolve(o),
+                    (SqlServerOptions o) => Evolve(o),
+                    (SQLiteOptions o) => Evolve(o),
                     _ => 1);
         }
 
-        static int Evolve(IDbConnection connection, Options options)
+        static int Evolve(Options options)
         {
-            EvolveFactory.Build(connection, options).ExecuteCommand();
+            EvolveFactory.Build(options).ExecuteCommand();
 
             return 0;
         }
-
-        static int EvolveWithCassandra(CassandraOptions cassandraOptions) =>
-            Evolve(new CqlConnection(cassandraOptions.ConnectionString), cassandraOptions);
-
-        static int EvolveWithMySql(MySqlOptions mySqlOptions) =>
-            Evolve(new MySqlConnection(mySqlOptions.ConnectionString), mySqlOptions);
-
-        static int EvolveWithPostgreSql(PostgreSqlOptions postgreSqlOptions) =>
-            Evolve(new NpgsqlConnection(postgreSqlOptions.ConnectionString), postgreSqlOptions);
-
-        static int EvolveWithSQLite(SQLiteOptions sqLiteOptions) =>
-#if NETCORE
-            Evolve(new SqliteConnection(sqLiteOptions.ConnectionString), sqLiteOptions);
-#elif NET
-            Evolve(new SQLiteConnection(sqLiteOptions.ConnectionString), sqLiteOptions);
-#endif
-
-        static int EvolveWithSqlServer(SqlServerOptions sqlServerOptions) =>
-            Evolve(new SqlConnection(sqlServerOptions.ConnectionString), sqlServerOptions);
     }
 }

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -1,10 +1,15 @@
 ﻿using Cassandra.Data;
 using CommandLine;
-using Microsoft.Data.Sqlite;
 using MySql.Data.MySqlClient;
 using Npgsql;
 using System.Data;
 using System.Data.SqlClient;
+
+#if NETCORE
+using Microsoft.Data.Sqlite;
+#elif NET
+using System.Data.SQLite;
+#endif
 
 namespace Evolve.Cli
 {
@@ -40,7 +45,11 @@ namespace Evolve.Cli
             Evolve(new NpgsqlConnection(postgreSqlOptions.ConnectionString), postgreSqlOptions);
 
         static int EvolveWithSQLite(SQLiteOptions sqLiteOptions) =>
+#if NETCORE
             Evolve(new SqliteConnection(sqLiteOptions.ConnectionString), sqLiteOptions);
+#elif NET
+            Evolve(new SQLiteConnection(sqLiteOptions.ConnectionString), sqLiteOptions);
+#endif
 
         static int EvolveWithSqlServer(SqlServerOptions sqlServerOptions) =>
             Evolve(new SqlConnection(sqlServerOptions.ConnectionString), sqlServerOptions);

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -1,5 +1,10 @@
 ﻿using Cassandra.Data;
 using CommandLine;
+using Microsoft.Data.Sqlite;
+using MySql.Data.MySqlClient;
+using Npgsql;
+using System.Data;
+using System.Data.SqlClient;
 
 namespace Evolve.Cli
 {
@@ -18,36 +23,26 @@ namespace Evolve.Cli
                     _ => 1);
         }
 
-
-        static int EvolveWithCassandra(CassandraOptions cassandraOptions)
+        static int Evolve(IDbConnection connection, Options options)
         {
-            var evolve = EvolveFactory.Build(
-                new CqlConnection(cassandraOptions.ConnectionString),
-                cassandraOptions);
-
-            evolve.ExecuteCommand();
+            EvolveFactory.Build(connection, options).ExecuteCommand();
 
             return 0;
         }
 
-        static int EvolveWithMySql(MySqlOptions mySqlOptions)
-        {
-            return 0;
-        }
+        static int EvolveWithCassandra(CassandraOptions cassandraOptions) =>
+            Evolve(new CqlConnection(cassandraOptions.ConnectionString), cassandraOptions);
 
-        static int EvolveWithPostgreSql(PostgreSqlOptions postgreSqlOptions)
-        {
-            return 0;
-        }
+        static int EvolveWithMySql(MySqlOptions mySqlOptions) =>
+            Evolve(new MySqlConnection(mySqlOptions.ConnectionString), mySqlOptions);
 
-        static int EvolveWithSqlServer(SqlServerOptions sqlServerOptions)
-        {
-            return 0;
-        }
+        static int EvolveWithPostgreSql(PostgreSqlOptions postgreSqlOptions) =>
+            Evolve(new NpgsqlConnection(postgreSqlOptions.ConnectionString), postgreSqlOptions);
 
-        static int EvolveWithSQLite(SQLiteOptions sqLiteOptions)
-        {
-            return 0;
-        }
+        static int EvolveWithSQLite(SQLiteOptions sqLiteOptions) =>
+            Evolve(new SqliteConnection(sqLiteOptions.ConnectionString), sqLiteOptions);
+
+        static int EvolveWithSqlServer(SqlServerOptions sqlServerOptions) =>
+            Evolve(new SqlConnection(sqlServerOptions.ConnectionString), sqlServerOptions);
     }
 }

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -1,0 +1,53 @@
+﻿using Cassandra.Data;
+using CommandLine;
+
+namespace Evolve.Cli
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Parser.Default
+                .ParseArguments<CassandraOptions, MySqlOptions, PostgreSqlOptions, SQLiteOptions, SqlServerOptions>(args)
+                .MapResult(
+                    (CassandraOptions o) => EvolveWithCassandra(o),
+                    (MySqlOptions o) => EvolveWithMySql(o),
+                    (PostgreSqlOptions o) => EvolveWithPostgreSql(o),
+                    (SqlServerOptions o) => EvolveWithSqlServer(o),
+                    (SQLiteOptions o) => EvolveWithSQLite(o),
+                    _ => 1);
+        }
+
+
+        static int EvolveWithCassandra(CassandraOptions cassandraOptions)
+        {
+            var evolve = EvolveFactory.Build(
+                new CqlConnection(cassandraOptions.ConnectionString),
+                cassandraOptions);
+
+            evolve.ExecuteCommand();
+
+            return 0;
+        }
+
+        static int EvolveWithMySql(MySqlOptions mySqlOptions)
+        {
+            return 0;
+        }
+
+        static int EvolveWithPostgreSql(PostgreSqlOptions postgreSqlOptions)
+        {
+            return 0;
+        }
+
+        static int EvolveWithSqlServer(SqlServerOptions sqlServerOptions)
+        {
+            return 0;
+        }
+
+        static int EvolveWithSQLite(SQLiteOptions sqLiteOptions)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/Evolve.Cli/SQLiteOptions.cs
+++ b/src/Evolve.Cli/SQLiteOptions.cs
@@ -3,5 +3,8 @@
 namespace Evolve.Cli
 {
     [Verb("sqlite", HelpText = "Evolve with SQLite")]
-    internal class SQLiteOptions : SqlOptions { }
+    internal class SQLiteOptions : SqlOptions
+    {
+        public override string Driver => "sqlite";
+    }
 }

--- a/src/Evolve.Cli/SQLiteOptions.cs
+++ b/src/Evolve.Cli/SQLiteOptions.cs
@@ -1,0 +1,7 @@
+﻿using CommandLine;
+
+namespace Evolve.Cli
+{
+    [Verb("sqlite", HelpText = "Evolve with SQLite")]
+    internal class SQLiteOptions : SqlOptions { }
+}

--- a/src/Evolve.Cli/SqlOptions.cs
+++ b/src/Evolve.Cli/SqlOptions.cs
@@ -1,0 +1,14 @@
+﻿using CommandLine;
+using System.Collections.Generic;
+
+namespace Evolve.Cli
+{
+    internal abstract class SqlOptions : Options
+    {
+        [Option('s', "metadata-table-schema", HelpText = "The schema in which the metadata table is/should be")]
+        public string MetadataTableSchema { get; set; }
+
+        [Option("schemas", HelpText = "A list of schema managed by Evolve. If empty, the default schema for the datasource connection is used.")]
+        public IEnumerable<string> Schemas { get; set; }
+    }
+}

--- a/src/Evolve.Cli/SqlServerOptions.cs
+++ b/src/Evolve.Cli/SqlServerOptions.cs
@@ -1,0 +1,7 @@
+﻿using CommandLine;
+
+namespace Evolve.Cli
+{
+    [Verb("sqlserver", HelpText = "Evolve with SQLServer")]
+    internal class SqlServerOptions : SqlOptions { }
+}

--- a/src/Evolve.Cli/SqlServerOptions.cs
+++ b/src/Evolve.Cli/SqlServerOptions.cs
@@ -3,5 +3,8 @@
 namespace Evolve.Cli
 {
     [Verb("sqlserver", HelpText = "Evolve with SQLServer")]
-    internal class SqlServerOptions : SqlOptions { }
+    internal class SqlServerOptions : SqlOptions
+    {
+        public override string Driver => "sqlserver";
+    }
 }

--- a/src/Evolve/Driver/MicrosoftDataSqliteDriver.cs
+++ b/src/Evolve/Driver/MicrosoftDataSqliteDriver.cs
@@ -9,10 +9,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "Microsoft.Data.Sqlite";
         public const string ConnectionTypeName = "Microsoft.Data.Sqlite.SqliteConnection";
-        public const string NugetPackageName = "Microsoft.Data.Sqlite";
+        public const string NugetPackageId = "Microsoft.Data.Sqlite";
 
         public CoreMicrosoftDataSqliteDriver(string depsFile, string nugetPackageDir)
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir)
         {
         }
     }
@@ -44,10 +44,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "Microsoft.Data.Sqlite";
         public const string ConnectionTypeName = "Microsoft.Data.Sqlite.SqliteConnection";
-        public const string NugetPackageName = "Microsoft.Data.Sqlite";
+        public const string NugetPackageId = "Microsoft.Data.Sqlite";
 
         public CoreMicrosoftDataSqliteDriverForNet(string depsFile, string nugetPackageDir, string msBuildExtensionsPath)
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir, msBuildExtensionsPath)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir, msBuildExtensionsPath)
         {
         }
     }

--- a/src/Evolve/Driver/MySqlDataDriver.cs
+++ b/src/Evolve/Driver/MySqlDataDriver.cs
@@ -9,10 +9,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "MySql.Data";
         public const string ConnectionTypeName = "MySql.Data.MySqlClient.MySqlConnection";
-        public const string NugetPackageName = "MySql.Data";
+        public const string NugetPackageId = "MySql.Data";
 
         public CoreMySqlDataDriver(string depsFile, string nugetPackageDir)
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir)
         {
         }
     }
@@ -44,10 +44,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "MySql.Data";
         public const string ConnectionTypeName = "MySql.Data.MySqlClient.MySqlConnection";
-        public const string NugetPackageName = "MySql.Data";
+        public const string NugetPackageId = "MySql.Data";
 
         public CoreMySqlDataDriverForNet(string depsFile, string nugetPackageDir, string msBuildExtensionsPath) 
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir, msBuildExtensionsPath)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir, msBuildExtensionsPath)
         {
         }
     }

--- a/src/Evolve/Driver/NpgsqlDriver.cs
+++ b/src/Evolve/Driver/NpgsqlDriver.cs
@@ -9,10 +9,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "Npgsql";
         public const string ConnectionTypeName = "Npgsql.NpgsqlConnection";
-        public const string NugetPackageName = "Npgsql";
+        public const string NugetPackageId = "Npgsql";
 
         public CoreNpgsqlDriver(string depsFile, string nugetPackageDir)
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir)
         {
         }
     }
@@ -44,10 +44,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "Npgsql";
         public const string ConnectionTypeName = "Npgsql.NpgsqlConnection";
-        public const string NugetPackageName = "Npgsql";
+        public const string NugetPackageId = "Npgsql";
 
         public CoreNpgsqlDriverForNet(string depsFile, string nugetPackageDir, string msBuildExtensionsPath) 
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir, msBuildExtensionsPath)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir, msBuildExtensionsPath)
         {
         }
     }

--- a/src/Evolve/Driver/SqlClientDriver.cs
+++ b/src/Evolve/Driver/SqlClientDriver.cs
@@ -9,10 +9,10 @@ namespace Evolve.Driver
     {
         public const string DriverAssemblyName = "System.Data.SqlClient";
         public const string ConnectionTypeName = "System.Data.SqlClient.SqlConnection";
-        public const string NugetPackageName = "System.Data.SqlClient";
+        public const string NugetPackageId = "System.Data.SqlClient";
 
         public CoreSqlClientDriver(string depsFile, string nugetPackageDir)
-            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageName, depsFile, nugetPackageDir)
+            : base(DriverAssemblyName, ConnectionTypeName, NugetPackageId, depsFile, nugetPackageDir)
         {
         }
     }

--- a/src/Evolve/Migration/MigrationVersion.cs
+++ b/src/Evolve/Migration/MigrationVersion.cs
@@ -35,6 +35,8 @@ namespace Evolve.Migration
 
         public static MigrationVersion MinVersion => new MigrationVersion("0");
 
+        public static MigrationVersion MaxVersion => new MigrationVersion(long.MaxValue.ToString());
+
         #region IComparable
 
         public int CompareTo(MigrationVersion other)

--- a/test/Evolve.IntegrationTest.Cassandra/.Evolve.Cassandra.KeyspaceDefaultReplicationStrategy
+++ b/test/Evolve.IntegrationTest.Cassandra/.Evolve.Cassandra.KeyspaceDefaultReplicationStrategy
@@ -1,2 +1,0 @@
-﻿class:NetworkTopologyStrategy
-dc1:1


### PR DESCRIPTION
Addressing #16 

The long awaited CLI :-)

It is in a separate project ```Evolve.Cli``` and targets ```net452```, ```netcoreapp1.1``` and ```netcoreapp2.0```. ```net35``` was dropped due to the lack of support of the [CommandLineParse](https://github.com/commandlineparser/commandline) library for this version of the framework.

The ```net452``` version is automatically packed as a unique ```Evolve.exe``` using IL-Repack in the cake script, it is then put in the ```distrib``` folder and uses the same version number as the Evolve assembly (```Evolve.exe --version```).

It is still a bit rough on the edges as it doesn't validate all arguments before calling ```Evolve```, but I think it will do for now and is ready for review, the missing bits can be added at later stages.