### PR TITLE
[WIP] Package the CLI as a .NET Core Global Tool

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,3 @@
-#tool "nuget:?package=ILRepack"
-
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 ///////////////////////////////////////////////////////////////////////////////
@@ -122,8 +120,12 @@ Task("Pack").Does(() =>
 
 Task("PackCli").WithCriteria(() => IsRunningOnWindows()).Does(() =>
 {
-    var assemblies = GetFiles("./src/Evolve.Cli/bin/Release/net452/*.dll");
-    ILRepack("./dist/Evolve.exe", "./src/Evolve.Cli/bin/Release/net452/Evolve.Cli.exe", assemblies);
+    var settings = new DotNetCorePackSettings
+    {
+        OutputDirectory = distDir.FullPath,
+    };
+
+    DotNetCorePack("./src/Evolve.Cli/Evolve.Cli.csproj", settings);
 });
 
 Task("Test CLI").Does(() =>

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -2,8 +2,19 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net452;</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <Version>$(PackageVersion)</Version>
+    <Authors>Philippe Lécaillon</Authors>
+    <PackageLicenseUrl>https://github.com/lecaillon/Evolve/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/lecaillon/Evolve</PackageProjectUrl>
+    <PackageIconUrl>https://github.com/lecaillon/Evolve/raw/master/logo128.png</PackageIconUrl>
+    <PackageDescription>Evolve is an easy migration tool that uses plain old sql scripts. Its purpose is to automate your database changes, and help keep those changes synchronized through all your environments and development teams.
+
+There are various NuGet packages for Evolve. This one provides Evolve as a command line application, as a .NET Core Global Tool.</PackageDescription>
+    <Copyright>Copyright © P.Lécaillon 2018</Copyright>
+    <PackageTags>Evolve Flyway sql database migration database-migration continuous-integration continuous-delivery</PackageTags>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>evolve</ToolCommandName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <DefineConstants>NET;NET45</DefineConstants>


### PR DESCRIPTION
This requires targetting netcoreapp2.1.

As a Global Tool, it should be possible to install the Evolve CLI as
follows:

    dotnet tool install -g Evolve.Cli

Then it should be possible to run the CLI, by simply running:

    evolve

Relates to <https://github.com/lecaillon/Evolve/issues/90>.