### PR TITLE
#157 Relax foreign key checks on MySQL drop schema

### DIFF
--- a/src/Evolve/Dialect/MySQL/MySQLSchema.cs
+++ b/src/Evolve/Dialect/MySQL/MySQLSchema.cs
@@ -38,7 +38,11 @@ namespace Evolve.Dialect.MySQL
 
         public override bool Drop()
         {
-            _wrappedConnection.ExecuteNonQuery($"DROP SCHEMA `{Name}`");
+            _wrappedConnection.ExecuteNonQuery("SET FOREIGN_KEY_CHECKS = 0");
+
+            _wrappedConnection.ExecuteNonQuery($"DROP SCHEMA IF EXISTS `{Name}`");
+
+            _wrappedConnection.ExecuteNonQuery("SET FOREIGN_KEY_CHECKS = 1");
 
             return true;
         }


### PR DESCRIPTION
This change relaxes foreign key constraint checking when dropping schemas that may have cross references.

`A.Table1` has a foreign key to `B.Table`.  Then try to `DROP SCHEMA B` as part of the `Erase` command. 💥 