### PR TITLE
Validation Flag to run scripts in verification mode

### DIFF
--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -95,6 +95,9 @@
         [Option("--out-of-order", "Allows migration scripts to be run “out of order”. Default: false", CommandOptionType.SingleValue)]
         public bool OutOfOrder { get; } = Default.OutOfOrder;
 
+        [Option("--validation-required", "Runs all the scripts in validation mode”. Default: false", CommandOptionType.SingleValue)]
+        public bool IsValidationRequired { get; } = Default.IsValidationRequired;
+
         [Option("--erase-disabled", "When set, ensures that Evolve will never erase schemas. Highly recommended in production. Default: false", CommandOptionType.SingleValue)]
         public bool EraseDisabled { get; } = Default.IsEraseDisabled;
 


### PR DESCRIPTION
For production case, we can't apply changes partially if any migration script fails in the process.

So it's better to run all the pending scripts in the validation mode prior directly executing the scripts.

Added validation-required flag by default false. This will run all scripts in transaction mode and rollbacks for success or failure cases. 
