### PR TITLE
Enabled use of Evolve CLI Placeholders with ':' in their value

### DIFF
--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -101,7 +101,7 @@
         {
             try
             {
-                return placeholders.Select(i => i.Split(':')).ToDictionary(i => prefix + i[0] + suffix, i => i[1]);
+                return placeholders.Select(i => i.Split(':', 2)).ToDictionary(i => prefix + i[0] + suffix, i => i[1]);
             }
             catch
             {


### PR DESCRIPTION
MapPlaceholders function now splits the placeholder string into 2 substrings (key & value). Before, it could split placeholders into 3 or more substrings, and would then ignore the extra substrings. This happened if the placeholder string has more than one ':' character.

This change is useful when using a placeholder to define a file path, for example in a CREATE DATABASE script.

Before this change, a placeholder with the value of "filename:C:\SqlServer\TestDb_data.mdf" will be mistakenly read by Evolve as "filename:C".
After this change, a placeholder with the value of "filename:C:\SqlServer\TestDb_data.mdf" will be correctly read by Evolve as "filename:C:\SqlServer\TestDb_data.mdf".