### PR TITLE
Implement validate command

### DIFF
--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -32,9 +32,9 @@
             }
         }
 
-        [Argument(0, Description = "migrate | erase | repair | info")]
+        [Argument(0, Description = "migrate | erase | repair | info | validate")]
         [Required]
-        [AllowedValues("migrate", "erase", "repair", "info", IgnoreCase = true)]
+        [AllowedValues("migrate", "erase", "repair", "info", "validate", IgnoreCase = true)]
         public CommandOptions Command { get; }
 
         [Argument(1, Description = "postgresql | sqlite | sqlserver | mysql | mariadb | cassandra | cockroachdb")]

--- a/src/Evolve/Configuration/CommandOptions.cs
+++ b/src/Evolve/Configuration/CommandOptions.cs
@@ -31,6 +31,11 @@
         /// <summary>
         ///     Prints details about migrations, what has been applied and what is pending.
         /// </summary>
-        Info
+        Info,
+        
+        /// <summary>
+        ///     Validate applied migrations, throws an exception if found not valid migration
+        /// </summary>
+        Validate
     }
 }

--- a/src/Evolve/Configuration/IEvolveConfiguration.cs
+++ b/src/Evolve/Configuration/IEvolveConfiguration.cs
@@ -48,6 +48,9 @@ namespace Evolve.Configuration
         ///     <para>
         ///         <see cref="CommandOptions.Info"/> : Prints details about migrations, what has been applied and what is pending.
         ///     </para>
+        ///     <para>
+        ///         <see cref="CommandOptions.Validate"/> : Validate applied migrations, throws an exception if found not valid migration
+        ///     </para>
         /// </summary>
         CommandOptions Command { get; set; }
 


### PR DESCRIPTION
In some user cases, migration can be executed external tool e.g. cli-tool and at the startup application, we need only validate applied migration.
And if migrations are a mismatch at the startup the application must be aborted. 
The command "validate" allows do it.