### PR TITLE
Support for Custom DBMS

### DIFF
--- a/src/Evolve/Connection/WrappedConnection.cs
+++ b/src/Evolve/Connection/WrappedConnection.cs
@@ -8,7 +8,7 @@ namespace EvolveDb.Connection
     /// <summary>
     ///     A wrapper of <see cref="IDbConnection"/> used to managed all the queries and transactions to the database to evolve.
     /// </summary>
-    internal class WrappedConnection : IDisposable
+    public class WrappedConnection : IDisposable
     {
         private const string NoAmbiantTransactionFound = "No ambiant transaction found to enlist in the WrappedConnection.";
         private const string TransactionAlreadyStarted = "The connection is already in a transaction and cannot participate in another transaction.";

--- a/src/Evolve/Dialect/DBMS.cs
+++ b/src/Evolve/Dialect/DBMS.cs
@@ -9,6 +9,7 @@
         SQLite,
         SQLServer,
         Cassandra,
-        CockroachDB
+        CockroachDB,
+        Custom
     }
 }

--- a/src/Evolve/Dialect/DatabaseHelper.cs
+++ b/src/Evolve/Dialect/DatabaseHelper.cs
@@ -5,7 +5,7 @@ using EvolveDb.Utilities;
 
 namespace EvolveDb.Dialect
 {
-    internal abstract class DatabaseHelper : IDisposable
+    public abstract class DatabaseHelper : IDisposable
     {
         private bool _disposedValue = false;
 

--- a/src/Evolve/Dialect/DatabaseHelperFactory.cs
+++ b/src/Evolve/Dialect/DatabaseHelperFactory.cs
@@ -26,9 +26,12 @@ namespace EvolveDb.Dialect
             [DBMS.CockroachDB]      = wcnn => new CockroachDBCluster(wcnn),
         };
 
-        public static DatabaseHelper GetDatabaseHelper(DBMS dbmsType, WrappedConnection connection)
+        public static DatabaseHelper GetDatabaseHelper(DBMS dbmsType, WrappedConnection connection, Func<WrappedConnection, DatabaseHelper>? customDbHelperCreationDelegate = null)
         {
             Check.NotNull(connection, nameof(connection));
+            
+            if (customDbHelperCreationDelegate != null)
+                return customDbHelperCreationDelegate(connection);
 
             _dbmsMap.TryGetValue(dbmsType, out Func<WrappedConnection, DatabaseHelper>? dbHelperCreationDelegate);
             if(dbHelperCreationDelegate is null)

--- a/src/Evolve/Dialect/Schema.cs
+++ b/src/Evolve/Dialect/Schema.cs
@@ -3,7 +3,7 @@ using EvolveDb.Utilities;
 
 namespace EvolveDb.Dialect
 {
-    internal abstract class Schema
+    public abstract class Schema
     {
         protected readonly WrappedConnection _wrappedConnection;
 

--- a/src/Evolve/Dialect/SimpleSqlStatementBuilder.cs
+++ b/src/Evolve/Dialect/SimpleSqlStatementBuilder.cs
@@ -6,7 +6,7 @@ namespace EvolveDb.Dialect
     ///     A simple sql statement builder that does nothing and returns only one 
     ///     sql statement that must be enlists in a transacation.
     /// </summary>
-    internal class SimpleSqlStatementBuilder : SqlStatementBuilderBase
+    public class SimpleSqlStatementBuilder : SqlStatementBuilderBase
     {
         public override string? BatchDelimiter => null;
 

--- a/src/Evolve/Dialect/SqlStatement.cs
+++ b/src/Evolve/Dialect/SqlStatement.cs
@@ -3,7 +3,7 @@
     /// <summary>
     ///     A SQL statement from a script that can be executed at once against a database.
     /// </summary>
-    internal class SqlStatement
+    public class SqlStatement
     {
         /// <summary>
         ///     Initialize a instance of the <see cref="SqlStatement"/> class.

--- a/src/Evolve/Dialect/SqlStatementBuilderBase.cs
+++ b/src/Evolve/Dialect/SqlStatementBuilderBase.cs
@@ -8,7 +8,7 @@ namespace EvolveDb.Dialect
     ///     A base class used to parse a SQL script and return a list of sql statements.
     ///     Each statement can then be executed depending its own database constraints,enlisted or not in a transaction.
     /// </summary>
-    internal abstract class SqlStatementBuilderBase
+    public abstract class SqlStatementBuilderBase
     {
         /// <summary>
         ///     Gets the database bacth delimiter.

--- a/src/Evolve/Extensions/MiscEx.cs
+++ b/src/Evolve/Extensions/MiscEx.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace EvolveDb
 {
-    internal static class MiscEx
+    public static class MiscEx
     {
         /// <summary>
         ///     Truncates a string to be no longer than a certain length.

--- a/src/Evolve/Extensions/WrappedConnectionEx.cs
+++ b/src/Evolve/Extensions/WrappedConnectionEx.cs
@@ -8,7 +8,7 @@ using EvolveDb.Utilities;
 
 namespace EvolveDb
 {
-    internal static class WrappedConnectionEx
+    public static class WrappedConnectionEx
     {
         private const string DBMSNotSupported = "Connection to this DBMS is not supported.";
 

--- a/src/Evolve/Metadata/IEvolveMetadata.cs
+++ b/src/Evolve/Metadata/IEvolveMetadata.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace EvolveDb.Metadata
 {
-    internal interface IEvolveMetadata
+    public interface IEvolveMetadata
     {
         /// <summary>
         ///     Try to lock the access to the metadata store to others migration processes.

--- a/src/Evolve/Metadata/MetadataTable.cs
+++ b/src/Evolve/Metadata/MetadataTable.cs
@@ -7,7 +7,7 @@ using EvolveDb.Utilities;
 
 namespace EvolveDb.Metadata
 {
-    internal abstract class MetadataTable : IEvolveMetadata
+    public abstract class MetadataTable : IEvolveMetadata
     {
         protected const string MigrationMetadataTypeNotSupported = "This method does not support the save of migration metadata. Use SaveMigration() instead.";
         protected readonly DatabaseHelper _database;

--- a/src/Evolve/Migration/MigrationMetadata.cs
+++ b/src/Evolve/Migration/MigrationMetadata.cs
@@ -3,7 +3,7 @@ using EvolveDb.Metadata;
 
 namespace EvolveDb.Migration
 {
-    internal class MigrationMetadata : MigrationBase
+    public class MigrationMetadata : MigrationBase
     {
         public MigrationMetadata(string? version, string description, string name, MetadataType type) 
             : base(version, description, name, type)


### PR DESCRIPTION
With this PR it is now possible to make a custom DBMS implementation.

The `Evolve` constructor can now have a custom implementation for `Func<WrappedConnection, DatabaseHelper>`.
By implementing `DatabaseHelper` with your custom DBMS you can have a complete custom implementation (in my case SingleStore) without affecting this library (and tests).

Biggest change to support this, is that some classes needed to become `public` instead of `internal`. I don't see any issue with this.

I really hope you accept this PR.
