### PR TITLE
Added mechanism for using an Azure access token when making a SQL Server connection

### DIFF
--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -94,7 +94,7 @@
                     cnn = new SQLiteConnection(cnnStr);
                     break;
                 case DBMS.SQLServer:
-                    cnn = new SqlConnection(cnnStr);
+                    cnn = new SqlConnection(cnnStr) { AccessToken = options.SqlServerAccessToken };
                     break;
                 case DBMS.Cassandra:
                     cnn = new CqlConnection(cnnStr);

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -125,5 +125,9 @@
 
         [Option("--metadata-table-keyspace", "The keyspace in which the metadata table is/should be (Cassandra only).", CommandOptionType.SingleValue)]
         public string MetadataTableKeyspace { get; }
+
+        // SQL Server
+        [Option("--sql-server-access-token", "An Azure-issued access token to be used when connecting to SQL Server.", CommandOptionType.SingleValue)]
+        public string SqlServerAccessToken { get; }
     }
 }

--- a/src/Evolve.Tool/Evolve.Tool.csproj
+++ b/src/Evolve.Tool/Evolve.Tool.csproj
@@ -29,6 +29,7 @@ Every time you build your project, it will automatically ensure that your databa
 - #224 Add SQL Server GO delimiter support in SQL comment
 - #228 Add new command Validate
 - #249 Add support of secrets in the connection string
+- #267 Add support for using Azure-issued access tokens with SQL Server connections
 
 ## Breaking changes
 - #250 Drop support of .NET Core 3.1, add support of .NET6


### PR DESCRIPTION
In order to facilitate authentication against SQL Server databases in Azure, Microsoft introduced access tokens to the **SqlConnection** class in **System.Data.SqlClient**.  This proposed change allows for the passing of an access token via the command line of the CLI and .NET Tool, and the use of that token when connecting to SQL Server.