### PR TITLE
Use Microsoft.Data packages instead of System.Data

### DIFF
--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="MySqlConnector" Version="2.1.13" />
     <PackageReference Include="Npgsql" Version="6.0.7" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -4,8 +4,8 @@
     using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
-    using System.Data.SqlClient;
-    using System.Data.SQLite;
+    using Microsoft.Data.SqlClient;
+    using Microsoft.Data.Sqlite;
     using System.Linq;
     using System.Reflection;
     using System.Text;
@@ -91,7 +91,7 @@
                     cnn = new NpgsqlConnection(cnnStr);
                     break;
                 case DBMS.SQLite:
-                    cnn = new SQLiteConnection(cnnStr);
+                    cnn = new SqliteConnection(cnnStr);
                     break;
                 case DBMS.SQLServer:
                     cnn = new SqlConnection(cnnStr) { AccessToken = options.SqlServerAccessToken };

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -7,11 +7,12 @@
     using Configuration;
     using Dialect;
     using McMaster.Extensions.CommandLineUtils;
+    using Microsoft.Data.Sqlite;
 
     [Command(ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated)]
     class Program
     {
-        private static readonly Evolve Default = new Evolve(new System.Data.SQLite.SQLiteConnection("Data Source=:memory:"));
+        private static readonly Evolve Default = new Evolve(new SqliteConnection("Data Source=:memory:"));
 
         static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);
 

--- a/src/Evolve.Tool/Evolve.Tool.csproj
+++ b/src/Evolve.Tool/Evolve.Tool.csproj
@@ -48,10 +48,10 @@ Every time you build your project, it will automatically ensure that your databa
   <ItemGroup>
     <PackageReference Include="CassandraCSharpDriver" Version="3.18.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.12" />
     <PackageReference Include="MySqlConnector" Version="2.1.13" />
     <PackageReference Include="Npgsql" Version="6.0.7" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I had problems with running Evolve on Windows on ARM, because  `System.Data.SQLite.Core` doesn't include ARM SQLite .dll, so I tried using `Microsoft.Data.Sqlite` package and it works perfectly.

`Microsoft.Data.Sqlite` includes .dll for many platforms (Windows, Linux, mac, x86, x64, ARM...).

I believe using Microsoft.Data.* libraries is the way forward and they include lot of improvements over their System.Data.* predecessors.