### PR TITLE
feat: net10

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Philippe Lécaillon
+Copyright (c) 2025 Philippe Lécaillon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ before_build:
       Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
       & ./dotnet-install.ps1 -Version $cliVersion -InstallDir $installDir
       $env:PATH = "$installDir;$installDir\dotnet;$env:PATH"
-- ps: dotnet tool install --global Cake.Tool
+- ps: dotnet tool install --global Cake.Tool --version 6.0.0
 
 # build
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,13 @@ before_build:
 - cmd: createdb --username=postgres my_database
 - cmd: SET MYSQL_PWD=Password12!
 - cmd: mysql -e "create database my_database;" --user=root
+- ps: |
+      $ErrorActionPreference = 'Stop'
+      $cliVersion = "10.0.100"
+      $installDir = "$env:USERPROFILE\dotnet10"
+      Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      & ./dotnet-install.ps1 -Version $cliVersion -InstallDir $installDir
+      $env:PATH = "$installDir;$installDir\dotnet;$env:PATH"
 - ps: dotnet tool install --global Cake.Tool
 
 # build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,6 @@ before_build:
 - cmd: SET MYSQL_PWD=Password12!
 - cmd: mysql -e "create database my_database;" --user=root
 - ps: |
-      $ErrorActionPreference = 'Stop'
       $cliVersion = "10.0.100"
       $installDir = "$env:USERPROFILE\dotnet10"
       Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.4.0</Version>
-    <AssemblyVersion>3.4.0.0</AssemblyVersion>
-    <FileVersion>3.4.0.0</FileVersion>
+    <Version>3.5.0</Version>
+    <AssemblyVersion>3.5.0.0</AssemblyVersion>
+    <FileVersion>3.5.0.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/samples/AspNetCoreSample_Evolve/AspNetCoreSample.csproj
+++ b/samples/AspNetCoreSample_Evolve/AspNetCoreSample.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Evolve" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.1" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Evolve" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AspNetCoreSample_Evolve_EmbeddedResources/AspNetCoreSample3.csproj
+++ b/samples/AspNetCoreSample_Evolve_EmbeddedResources/AspNetCoreSample3.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Evolve" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.1" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Evolve" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Evolve.Cli/Evolve.Cli.csproj
+++ b/src/Evolve.Cli/Evolve.Cli.csproj
@@ -3,19 +3,19 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PublishTrimmed>true</PublishTrimmed>
     <RootNamespace>EvolveDb.Cli</RootNamespace>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="CassandraCSharpDriver" Version="3.20.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.118" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.119" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Evolve.Cli/EvolveFactory.cs
+++ b/src/Evolve.Cli/EvolveFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace EvolveDb.Cli
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EvolveDb.Cli
 {
     using System;
     using System.Collections.Generic;
@@ -15,6 +17,7 @@
     using MySqlConnector;
     using Npgsql;
 
+    [RequiresUnreferencedCode("This functionality is not compatible with trimming")]
     internal static class EvolveFactory
     {
         public static Evolve Build(Program options, Action<string> logInfoDelegate = null)

--- a/src/Evolve.Cli/Program.cs
+++ b/src/Evolve.Cli/Program.cs
@@ -1,4 +1,6 @@
-﻿namespace EvolveDb.Cli;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EvolveDb.Cli;
 
 using Configuration;
 using Dialect;
@@ -9,6 +11,7 @@ using System.Linq;
 using AllowedValuesAttribute = McMaster.Extensions.CommandLineUtils.AllowedValuesAttribute;
 
 [Command(ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated)]
+[RequiresUnreferencedCode("This functionality is not compatible with trimming")]
 class Program
 {
     private static readonly Evolve Default = new(new System.Data.SQLite.SQLiteConnection("Data Source=:memory:"));
@@ -118,7 +121,7 @@ class Program
 
     [Option("-f|--embedded-resource-filter", "When set, exclude embedded migration scripts that do not start with one of these filters.", CommandOptionType.MultipleValue)]
     public string[] EmbeddedResourceFilters { get; }
- 
+
     [Option("--retry-repeatable", "When set, execute repeatedly all repeatable migrations for as long as the number of errors decreases, so that you can name them more easily. Default: false", CommandOptionType.SingleValue)]
     public bool RetryRepeatableMigrationsUntilNoError { get; } = Default.RetryRepeatableMigrationsUntilNoError;
 

--- a/src/Evolve.Tool/Evolve.Tool.csproj
+++ b/src/Evolve.Tool/Evolve.Tool.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>evolve</ToolCommandName>
     <RootNamespace>EvolveDb.Tool</RootNamespace>
@@ -14,7 +14,7 @@
     <Title>Database migration tool for .NET. Inspired by Flyway.</Title>
     <Authors>Philippe Lécaillon</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>Copyright © P.Lécaillon 2021</Copyright>
+    <Copyright>Copyright © P.Lécaillon 2025</Copyright>
     <Description>Evolve is an easy migration tool that uses plain old sql scripts. Its purpose is to automate your database changes, and help keep those changes synchronized through all your environments and developpement teams.
 Every time you build your project, it will automatically ensure that your database is up-to-date, without having to do anything other than build. Install it and forget it !</Description>
     <RepositoryType>git</RepositoryType>
@@ -23,8 +23,7 @@ Every time you build your project, it will automatically ensure that your databa
     <RepositoryUrl>https://github.com/lecaillon/Evolve.git</RepositoryUrl>
     <PackageTags>evolve flyway dotnet tool sql database migration mysql sqlserver cassandra mariadb sqlite postgresql cockroachdb</PackageTags>
     <PackageReleaseNotes>## Features
-- Add .NET 9 support, drop .NET 7/8 support
-- Remove support for netstandard2.0</PackageReleaseNotes>
+- Add .NET 10 support, drop .NET 9 support</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,12 +32,13 @@ Every time you build your project, it will automatically ensure that your databa
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CassandraCSharpDriver" Version="3.20.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.118" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.119" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Evolve/Evolve.csproj
+++ b/src/Evolve/Evolve.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <LangVersion>latest</LangVersion>

--- a/src/Evolve/Evolve.nuspec
+++ b/src/Evolve/Evolve.nuspec
@@ -13,9 +13,8 @@ Every time you build your project, it will automatically ensure that your databa
     <repository type="git" url="https://github.com/lecaillon/Evolve.git" />
     <iconUrl>https://raw.githubusercontent.com/lecaillon/Evolve/master/images/logo128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>## Features
-- Add .NET 9 support, drop .NET 8 support
-- Remove support for netstandard2.0</releaseNotes>
+    <PackageReleaseNotes>## Features
+- Add .NET 10 support, drop .NET 9 support</PackageReleaseNotes>
     <tags>evolve flyway sql database migration mysql sqlserver cassandra mariadb sqlite postgresql cockroachdb</tags>
     <dependencies>
       <group targetFramework="net10.0" />

--- a/src/Evolve/Evolve.nuspec
+++ b/src/Evolve/Evolve.nuspec
@@ -18,12 +18,12 @@ Every time you build your project, it will automatically ensure that your databa
 - Remove support for netstandard2.0</releaseNotes>
     <tags>evolve flyway sql database migration mysql sqlserver cassandra mariadb sqlite postgresql cockroachdb</tags>
     <dependencies>
-      <group targetFramework="net9.0" />
+      <group targetFramework="net10.0" />
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\net9.0\Evolve.dll" target="lib\net9.0" />
-    <file src="bin\Release\net9.0\Evolve.pdb" target="lib\net9.0" />
-    <file src="bin\Release\net9.0\Evolve.xml" target="lib\net9.0" />
+    <file src="bin\Release\net10.0\Evolve.dll" target="lib\net10.0" />
+    <file src="bin\Release\net10.0\Evolve.pdb" target="lib\net10.0" />
+    <file src="bin\Release\net10.0\Evolve.xml" target="lib\net10.0" />
   </files>
 </package>

--- a/test/Evolve.Tests/Connection/WrappedConnectionTest.cs
+++ b/test/Evolve.Tests/Connection/WrappedConnectionTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Connection
 {
-    public record WrappedConnectionTest : DbContainerFixture<PostgreSqlContainer>
+    public sealed class WrappedConnectionTest : DbContainerFixture<PostgreSqlContainer>
     {
         [Fact]
         [Category(Test.Connection)]

--- a/test/Evolve.Tests/Evolve.Tests.csproj
+++ b/test/Evolve.Tests/Evolve.Tests.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>EvolveDb.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="altcover" Version="8.6.125" />
-    <PackageReference Include="CassandraCSharpDriver" Version="3.20.0" />
+    <PackageReference Include="altcover" Version="9.0.102" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.118" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="Stub.System.Data.SQLite.Core.NetStandard" Version="1.0.119" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Evolve.Tests/Infrastructure/_Internal/DbContainerFixture.cs
+++ b/test/Evolve.Tests/Infrastructure/_Internal/DbContainerFixture.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Infrastructure
 {
-    public abstract record DbContainerFixture<T> : IAsyncLifetime where T : IDbContainer, new()
+    public abstract class DbContainerFixture<T> : IAsyncLifetime where T : IDbContainer, new()
     {
         private static readonly SemaphoreSlim Semaphore = new(1);
 
@@ -18,7 +18,7 @@ namespace EvolveDb.Tests.Infrastructure
         public virtual bool MustRunContainer { get; } = TestContext.Local;
         public virtual Action Initialize { get; }
 
-        public DbConnection CreateDbConnection() => _container.CreateDbConnection();
+        internal DbConnection CreateDbConnection() => _container.CreateDbConnection();
 
         public async Task InitializeAsync()
         {

--- a/test/Evolve.Tests/Integration/Cassandra/DialectTest.cs
+++ b/test/Evolve.Tests/Integration/Cassandra/DialectTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Integration.Cassandra
 {
-    public record DialectTest : DbContainerFixture<CassandraContainer>
+    public sealed class DialectTest : DbContainerFixture<CassandraContainer>
     {
         /// <summary>
         ///     Second part of the integration test.

--- a/test/Evolve.Tests/Integration/Cassandra/MigrationTest.cs
+++ b/test/Evolve.Tests/Integration/Cassandra/MigrationTest.cs
@@ -5,7 +5,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration.Cassandra
 {
-    public record MigrationTest(ITestOutputHelper Output) : DbContainerFixture<CassandraContainer>
+    public sealed class MigrationTest(ITestOutputHelper Output) : DbContainerFixture<CassandraContainer>
     {
         [FactSkippedOnAppVeyor]
         [Category(Test.Cassandra)]

--- a/test/Evolve.Tests/Integration/CockroachDB/DialectTest.cs
+++ b/test/Evolve.Tests/Integration/CockroachDB/DialectTest.cs
@@ -5,7 +5,7 @@ using EvolveDb.Tests.Infrastructure;
 
 namespace EvolveDb.Tests.Integration.CockroachDb
 {
-    public record DialectTest : DbContainerFixture<CockroachDBContainer>
+    public sealed class DialectTest : DbContainerFixture<CockroachDBContainer>
     {
         [FactSkippedOnAppVeyor]
         [Category(Test.CockroachDB)]

--- a/test/Evolve.Tests/Integration/CockroachDB/MigrationTest.cs
+++ b/test/Evolve.Tests/Integration/CockroachDB/MigrationTest.cs
@@ -5,7 +5,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration.CockroachDb
 {
-    public record MigrationTests(ITestOutputHelper Output) : DbContainerFixture<CockroachDBContainer>
+    public sealed class MigrationTests(ITestOutputHelper Output) : DbContainerFixture<CockroachDBContainer>
     {
         [Fact(Skip = "System.InvalidOperationException : This NpgsqlTransaction has completed; it is no longer usable.")]
         //[FactSkippedOnAppVeyor]

--- a/test/Evolve.Tests/Integration/MySQL/DialectTest.cs
+++ b/test/Evolve.Tests/Integration/MySQL/DialectTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Integration.MySql
 {
-    public record DialectTest : DbContainerFixture<MySQLContainer>
+    public sealed class DialectTest : DbContainerFixture<MySQLContainer>
     {
         [Fact]
         [Category(Test.MySQL)]

--- a/test/Evolve.Tests/Integration/MySQL/MigrationTest.cs
+++ b/test/Evolve.Tests/Integration/MySQL/MigrationTest.cs
@@ -5,7 +5,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration.MySql
 {
-    public record MigrationTest(ITestOutputHelper Output) : DbContainerFixture<MySQLContainer>
+    public sealed class MigrationTest(ITestOutputHelper Output) : DbContainerFixture<MySQLContainer>
     {
         [Fact]
         [Category(Test.MySQL)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/DialectTest.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/DialectTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Integration.PostgregSql
 {
-    public record DialectTest : DbContainerFixture<PostgreSqlContainer>
+    public sealed class DialectTest : DbContainerFixture<PostgreSqlContainer>
     {
         [Fact]
         [Category(Test.PostgreSQL)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/MigrationTest.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/MigrationTest.cs
@@ -7,7 +7,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration.PostgregSql
 {
-    public record MigrationTests(ITestOutputHelper Output) : DbContainerFixture<PostgreSqlContainer>
+    public sealed class MigrationTests(ITestOutputHelper Output) : DbContainerFixture<PostgreSqlContainer>
     {
         [Fact]
         [Category(Test.PostgreSQL)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario001.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario001.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario001(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario001(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario002.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario002.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario002(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario002(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario003.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario003.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario003(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario003(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario004.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario004.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario004(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario004(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario005.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario005.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario005(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario005(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario006.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario006.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario006(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario006(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario007.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario007.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario007(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario007(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario008.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario008.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario008(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario008(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/PostgreSQL/Scenario009.cs
+++ b/test/Evolve.Tests/Integration/PostgreSQL/Scenario009.cs
@@ -4,7 +4,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.PostgreSql
 {
-    public record Scenario009(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
+    public sealed class Scenario009(ITestOutputHelper Output) : Scenario<PostgreSqlContainer>(Output)
     {
         [Fact]
         [Category(Test.PostgreSQL, Test.Sceanario)]

--- a/test/Evolve.Tests/Integration/SQLServer/DialectTest.cs
+++ b/test/Evolve.Tests/Integration/SQLServer/DialectTest.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace EvolveDb.Tests.Integration.SQLServer
 {
-    public record DialectTest : DbContainerFixture<SQLServerContainer>
+    public sealed class DialectTest : DbContainerFixture<SQLServerContainer>
     {
         public const string DbName = "my_database_1";
 

--- a/test/Evolve.Tests/Integration/SQLServer/MigrationTest.cs
+++ b/test/Evolve.Tests/Integration/SQLServer/MigrationTest.cs
@@ -8,7 +8,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration.SQLServer
 {
-    public record MigrationTest(ITestOutputHelper Output) : DbContainerFixture<SQLServerContainer>
+    public sealed class MigrationTest(ITestOutputHelper Output) : DbContainerFixture<SQLServerContainer>
     {
         public const string DbName = "my_database_2";
 

--- a/test/Evolve.Tests/Integration/SQLServer/Scenario101.cs
+++ b/test/Evolve.Tests/Integration/SQLServer/Scenario101.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.SQLServer
 {
-    public record Scenario101 : Scenario<SQLServerContainer>
+    public sealed class Scenario101 : Scenario<SQLServerContainer>
     {
         public Scenario101(ITestOutputHelper output) : base(output) { }
 

--- a/test/Evolve.Tests/Integration/SQLServer/Scenario102.cs
+++ b/test/Evolve.Tests/Integration/SQLServer/Scenario102.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 
 namespace EvolveDb.Tests.Integration.SQLServer
 {
-    public record Scenario102 : Scenario<SQLServerContainer>
+    public sealed class Scenario102 : Scenario<SQLServerContainer>
     {
         public Scenario102(ITestOutputHelper output) : base(output) { }
 

--- a/test/Evolve.Tests/Integration/ScenarioBase.cs
+++ b/test/Evolve.Tests/Integration/ScenarioBase.cs
@@ -11,7 +11,7 @@ using static EvolveDb.Tests.TestContext;
 
 namespace EvolveDb.Tests.Integration
 {
-    public abstract record Scenario<T>(ITestOutputHelper Output) : DbContainerFixture<T> where T : IDbContainer, new()
+    public abstract class Scenario<T>(ITestOutputHelper Output) : DbContainerFixture<T> where T : IDbContainer, new()
     {
         protected readonly T _dbContainer = new();
 


### PR DESCRIPTION
@lecaillon from what I understand only you can update the AZDO pipeline to add net10 as a dependency.

On AppVeyor side the latest available image is Visual Studio 2022 so I tried to add net10 manually but the build fails with a non explicit message:

```ps
dotnet tool install --global Cake.Tool --version 6.0.0
dotnet : 
At line:1 char:1
+ dotnet tool install --global Cake.Tool --version 6.0.0
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
Welcome to .NET 10.0!
---------------------
SDK Version: 10.0.100
Telemetry
---------
The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment 
variable to '1' or 'true' using your favorite shell.
Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry
----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate, run 'dotnet dev-certs https --trust'
Learn about HTTPS: https://aka.ms/dotnet-https
----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
You can invoke the tool using the following command: dotnet-cake
Tool 'cake.tool' (version '6.0.0') was successfully installed.
Command executed with exception: --------------------------------------------------------------------------------------
```